### PR TITLE
extension-point-for-swagger-3.0 : added extension points for the open…

### DIFF
--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/field/completion/openapi/InfoCompletion.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/field/completion/openapi/InfoCompletion.java
@@ -1,0 +1,18 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.field.completion.openapi;
+
+import com.intellij.codeInsight.completion.CompletionResultSet;
+import org.zalando.intellij.swagger.completion.CompletionHelper;
+import org.zalando.intellij.swagger.completion.field.FieldCompletion;
+
+public class InfoCompletion extends FieldCompletion {
+
+    private int key;
+
+    public InfoCompletion(final CompletionHelper completionHelper, final CompletionResultSet completionResultSet,) {
+        super(completionHelper, completionResultSet);
+    }
+
+    public void fill() {
+        OpenApiFields.info().forEach(this::addUnique);
+    }
+}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/field/completion/openapi/OpenApiFieldFactory.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/field/completion/openapi/OpenApiFieldFactory.java
@@ -1,0 +1,23 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.field.completion.openapi;
+
+import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.util.Optional;
+
+import org.zalando.intellij.swagger.completion.OpenApiCompletionHelper;
+import org.zalando.intellij.swagger.completion.field.FieldCompletion;
+import org.zalando.intellij.swagger.extensions.completion.openapi.OpenApiCustomFieldCompletionFactory;
+
+public class OpenApiFieldFactory implements OpenApiCustomFieldCompletionFactory {
+
+    @Override
+    public Optional<FieldCompletion> from(
+            OpenApiCompletionHelper openApiCompletionHelper, CompletionResultSet completionResultSet) {
+        if (openApiCompletionHelper.hasPath("$.info")) {
+            return Optional.of(new InfoCompletion(openApiCompletionHelper, completionResultSet));
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/field/completion/openapi/OpenApiFields.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/field/completion/openapi/OpenApiFields.java
@@ -1,0 +1,16 @@
+package org.zalando.intellij.swagger.examples.extensions.zalando.field.completion.openapi;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.zalando.intellij.swagger.completion.field.model.common.Field;
+import org.zalando.intellij.swagger.completion.field.model.common.StringField;
+
+class OpenApiFields {
+
+  static List<Field> info() {
+    return ImmutableList.of(
+        new StringField("x-api-id", true),
+        new StringField("x-audience", true)
+    );
+  }
+}

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/ZallySettingsGui.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/ZallySettingsGui.java
@@ -85,7 +85,7 @@ public class ZallySettingsGui implements SearchableConfigurable {
 
   private boolean ztokenPathUpdated(final ZallySettings settings) {
     return settings.getZtokenPath() != null
-            && !settings.getZtokenPath().equals(ztokenPathTextField.getText());
+        && !settings.getZtokenPath().equals(ztokenPathTextField.getText());
   }
 
   private boolean ztokenPathCreated(final ZallySettings settings) {

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/ZallyYamlFileValidator.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/ZallyYamlFileValidator.java
@@ -14,6 +14,8 @@ import com.intellij.openapi.options.ShowSettingsUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import java.util.List;
+import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.yaml.psi.YAMLKeyValue;
 import org.zalando.intellij.swagger.examples.extensions.zalando.validator.ZallySettingsGui;
@@ -21,9 +23,6 @@ import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.
 import org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.model.Violation;
 import org.zalando.intellij.swagger.file.FileDetector;
 import org.zalando.intellij.swagger.traversal.path.PathFinder;
-
-import java.util.List;
-import java.util.Optional;
 
 public class ZallyYamlFileValidator extends LocalInspectionTool {
 

--- a/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/TokenService.java
+++ b/examples/extensions-zalando/src/main/java/org/zalando/intellij/swagger/examples/extensions/zalando/validator/zally/http/TokenService.java
@@ -1,14 +1,13 @@
 package org.zalando.intellij.swagger.examples.extensions.zalando.validator.zally.http;
 
 import com.intellij.openapi.components.ServiceManager;
-import org.apache.commons.io.IOUtils;
-import org.zalando.intellij.swagger.examples.extensions.zalando.validator.ZallySettings;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.IOUtils;
+import org.zalando.intellij.swagger.examples.extensions.zalando.validator.ZallySettings;
 
 public class TokenService {
 

--- a/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
+++ b/examples/extensions-zalando/src/main/resources/META-INF/plugin.xml
@@ -19,6 +19,11 @@
         <customValueFactory implementation="org.zalando.intellij.swagger.examples.extensions.zalando.value.completion.swagger.SwaggerValueFactory" />
     </extensions>
 
+    <extensions defaultExtensionNs="org.zalando.intellij.openapi">
+        <customFieldFactory implementation="org.zalando.intellij.swagger.examples.extensions.zalando.field.completion.swagger.SwaggerFieldFactory" />
+        <customValueFactory implementation="org.zalando.intellij.swagger.examples.extensions.zalando.value.completion.swagger.SwaggerValueFactory" />
+    </extensions>
+
     <extensions defaultExtensionNs="com.intellij">
 
         <localInspection displayName="Zally Linter" groupName="Zally Linter" language="yaml"

--- a/src/main/java/org/zalando/intellij/swagger/completion/contributor/openapi/OpenApiJsonCompletionContributor.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/contributor/openapi/OpenApiJsonCompletionContributor.java
@@ -12,6 +12,8 @@ import org.zalando.intellij.swagger.completion.field.FieldCompletion;
 import org.zalando.intellij.swagger.completion.field.completion.openapi.OpenApiFieldCompletionFactory;
 import org.zalando.intellij.swagger.completion.value.ValueCompletion;
 import org.zalando.intellij.swagger.completion.value.completion.openapi.OpenApiValueCompletionFactory;
+import org.zalando.intellij.swagger.extensions.completion.openapi.OpenApiCustomFieldCompletionFactory;
+import org.zalando.intellij.swagger.extensions.completion.openapi.OpenApiCustomValueCompletionFactory;
 import org.zalando.intellij.swagger.file.OpenApiFileType;
 import org.zalando.intellij.swagger.index.openapi.OpenApiIndexService;
 import org.zalando.intellij.swagger.traversal.JsonTraversal;
@@ -51,10 +53,18 @@ public class OpenApiJsonCompletionContributor extends CompletionContributor {
           if (jsonTraversal.isKey(psiElement)) {
             OpenApiFieldCompletionFactory.from(completionHelper, result)
                 .ifPresent(FieldCompletion::fill);
+            for (OpenApiCustomFieldCompletionFactory ep :
+                OpenApiCustomFieldCompletionFactory.EP_NAME.getExtensions()) {
+              ep.from(completionHelper, result).ifPresent(FieldCompletion::fill);
+            }
           } else {
             OpenApiValueCompletionFactory.from(
                     completionHelper, CompletionResultSetFactory.forValue(parameters, result))
                 .ifPresent(ValueCompletion::fill);
+            for (OpenApiCustomValueCompletionFactory ep :
+                OpenApiCustomValueCompletionFactory.EP_NAME.getExtensions()) {
+              ep.from(completionHelper, result).ifPresent(ValueCompletion::fill);
+            }
           }
 
           result.stopHere();

--- a/src/main/java/org/zalando/intellij/swagger/completion/contributor/openapi/OpenApiYamlCompletionContributor.java
+++ b/src/main/java/org/zalando/intellij/swagger/completion/contributor/openapi/OpenApiYamlCompletionContributor.java
@@ -12,6 +12,8 @@ import org.zalando.intellij.swagger.completion.field.FieldCompletion;
 import org.zalando.intellij.swagger.completion.field.completion.openapi.OpenApiFieldCompletionFactory;
 import org.zalando.intellij.swagger.completion.value.ValueCompletion;
 import org.zalando.intellij.swagger.completion.value.completion.openapi.OpenApiValueCompletionFactory;
+import org.zalando.intellij.swagger.extensions.completion.openapi.OpenApiCustomFieldCompletionFactory;
+import org.zalando.intellij.swagger.extensions.completion.openapi.OpenApiCustomValueCompletionFactory;
 import org.zalando.intellij.swagger.file.OpenApiFileType;
 import org.zalando.intellij.swagger.index.openapi.OpenApiIndexService;
 import org.zalando.intellij.swagger.traversal.YamlTraversal;
@@ -54,6 +56,16 @@ public class OpenApiYamlCompletionContributor extends CompletionContributor {
           OpenApiValueCompletionFactory.from(
                   completionHelper, CompletionResultSetFactory.forValue(parameters, result))
               .ifPresent(ValueCompletion::fill);
+
+          for (OpenApiCustomFieldCompletionFactory ep :
+              OpenApiCustomFieldCompletionFactory.EP_NAME.getExtensions()) {
+            ep.from(completionHelper, result).ifPresent(FieldCompletion::fill);
+          }
+
+          for (OpenApiCustomValueCompletionFactory ep :
+              OpenApiCustomValueCompletionFactory.EP_NAME.getExtensions()) {
+            ep.from(completionHelper, result).ifPresent(ValueCompletion::fill);
+          }
 
           result.stopHere();
         });

--- a/src/main/java/org/zalando/intellij/swagger/extensions/completion/openapi/OpenApiCustomFieldCompletionFactory.java
+++ b/src/main/java/org/zalando/intellij/swagger/extensions/completion/openapi/OpenApiCustomFieldCompletionFactory.java
@@ -1,0 +1,16 @@
+package org.zalando.intellij.swagger.extensions.completion.openapi;
+
+import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.openapi.extensions.ExtensionPointName;
+import java.util.Optional;
+import org.zalando.intellij.swagger.completion.OpenApiCompletionHelper;
+import org.zalando.intellij.swagger.completion.field.FieldCompletion;
+
+public interface OpenApiCustomFieldCompletionFactory {
+  ExtensionPointName<OpenApiCustomFieldCompletionFactory> EP_NAME =
+      ExtensionPointName.create("org.zalando.intellij.openapi.customFieldFactory");
+
+  Optional<FieldCompletion> from(
+      final OpenApiCompletionHelper completionHelper,
+      final CompletionResultSet completionResultSet);
+}

--- a/src/main/java/org/zalando/intellij/swagger/extensions/completion/openapi/OpenApiCustomValueCompletionFactory.java
+++ b/src/main/java/org/zalando/intellij/swagger/extensions/completion/openapi/OpenApiCustomValueCompletionFactory.java
@@ -1,0 +1,16 @@
+package org.zalando.intellij.swagger.extensions.completion.openapi;
+
+import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.openapi.extensions.ExtensionPointName;
+import java.util.Optional;
+import org.zalando.intellij.swagger.completion.OpenApiCompletionHelper;
+import org.zalando.intellij.swagger.completion.value.ValueCompletion;
+
+public interface OpenApiCustomValueCompletionFactory {
+  ExtensionPointName<OpenApiCustomValueCompletionFactory> EP_NAME =
+      ExtensionPointName.create("org.zalando.intellij.openapi.customValueFactory");
+
+  Optional<ValueCompletion> from(
+      final OpenApiCompletionHelper completionHelper,
+      final CompletionResultSet completionResultSet);
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -19,6 +19,8 @@
     <extensionPoints>
         <extensionPoint qualifiedName="org.zalando.intellij.swagger.customFieldFactory" interface="org.zalando.intellij.swagger.extensions.completion.swagger.SwaggerCustomFieldCompletionFactory"/>
         <extensionPoint qualifiedName="org.zalando.intellij.swagger.customValueFactory" interface="org.zalando.intellij.swagger.extensions.completion.swagger.SwaggerCustomValueCompletionFactory"/>
+        <extensionPoint qualifiedName="org.zalando.intellij.openapi.customFieldFactory" interface="org.zalando.intellij.swagger.extensions.completion.openapi.OpenApiCustomFieldCompletionFactory"/>
+        <extensionPoint qualifiedName="org.zalando.intellij.openapi.customValueFactory" interface="org.zalando.intellij.swagger.extensions.completion.openapi.OpenApiCustomValueCompletionFactory"/>
     </extensionPoints>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
…api(swagger 3.0) which can be used to provide custom extensions for the openapi. Also added the example for the openapi extensions for field